### PR TITLE
Added main.yml file to setup a GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI on Push and Pull Request
+
+on: [push, pull_request]
+
+jobs:
+  Android:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Android
+      run: |
+        cd CauserException
+        nuget restore
+        cd CauserException.Android
+        msbuild CauserException.Android.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
+        
+  iOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: iOS
+      run: |
+        cd CauserException
+        nuget restore
+        msbuild CauserException.iOS/CauserException.iOS.csproj /verbosity:normal /t:Rebuild /p:Platform=iPhoneSimulator /p:Configuration=Debug


### PR DESCRIPTION
* Added main.yml file that orders 2 jobs on every push and merge request
* One job is to build iOS and the other builds Android

**Purpose of Action**
-----
* The action performs a sanity test on your apps— makes sure the iOS & Android apps build on each commit or merge request, ensuring that there is no bug introduced in that commit
* More details in [the article](https://medium.com/@prototypemakers/using-github-actions-with-ios-and-android-xamarin-apps-693a93b48a61) or the corresponding [unmetered article link](https://medium.com/@prototypemakers/using-github-actions-with-ios-and-android-xamarin-apps-693a93b48a61?sk=cd81773f2e5a5931ae49c9362b4db795)

**Testing**
--------
* Tested the Action on [my fork](https://github.com/saamerm/ReleaseEverywhereBuildOnce/commit/d2e8310f1e6fed99cbb406ee857fc3fab613513b/checks?check_suite_id=396808524) and it passed the tests